### PR TITLE
Set the default hotkey for the extension

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -7,7 +7,7 @@
   "default_locale": "en",
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "options_page": "views/default.html#/settings/account",
-  "minimum_chrome_version": "23",
+  "minimum_chrome_version": "28",
   "icons": {
     "16": "icons/16.png",
     "48": "icons/48.png",
@@ -29,6 +29,11 @@
       "/app/lib/notifications.js",
       "/app/bootstrap-bg.js"
     ]
+  },
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {"default": "Alt+J"}
+    }
   },
   "permissions": [
     "storage",


### PR DESCRIPTION
- Minimum chrome version changed from 23 to 28
- Added default hotkey for the extension
closes #98